### PR TITLE
Update ruby version to 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/daffy_lib
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7.0
 
     steps:
       - checkout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - node_modules/**/*
     - output/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.6.5
+  TargetRubyVersion: 2.7.0
   RSpec:
     Patterns:
       - _spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '2.6.5'
+ruby '2.7.0'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,8 +91,8 @@ GEM
       json
       simplecov
       url
-    concurrent-ruby (1.1.5)
-    crass (1.0.5)
+    concurrent-ruby (1.1.6)
+    crass (1.0.6)
     diff-lcs (1.3)
     docile (1.3.2)
     encryptor (3.0.0)
@@ -105,7 +105,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.7.1)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     jmespath (1.4.0)
@@ -121,7 +121,7 @@ GEM
     mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     msgpack (1.3.3)
     nio4r (2.5.2)
     nokogiri (1.10.8)
@@ -135,7 +135,7 @@ GEM
       msgpack
       rbnacl (= 5.0.0)
       rbnacl-libsodium
-    rack (2.0.8)
+    rack (2.2.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.2.1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/Zetatango/daffy_lib.svg?style=svg)](https://circleci.com/gh/Zetatango/daffy_lib) [![codecov](https://codecov.io/gh/Zetatango/daffy_lib/branch/master/graph/badge.svg?token=WxED9350q4)](https://codecov.io/gh/Zetatango/daffy_lib) [![Gem Version](https://badge.fury.io/rb/daffy_lib.svg)](https://badge.fury.io/rb/daffy_lib) 
+[![CircleCI](https://circleci.com/gh/Zetatango/daffy_lib.svg?style=svg)](https://circleci.com/gh/Zetatango/daffy_lib) [![codecov](https://codecov.io/gh/Zetatango/daffy_lib/branch/master/graph/badge.svg?token=WxED9350q4)](https://codecov.io/gh/Zetatango/daffy_lib) [![Gem Version](https://badge.fury.io/rb/daffy_lib.svg)](https://badge.fury.io/rb/daffy_lib)
 # DaffyLib
 
 This gem is a caching encryptor which improves performance when encrypting/decrypting large amounts of data.  It will keep a plaintext key cached for a given amount of time, as well as provide partitioning to allow entire rows to be encrypted with the same key.  Keys are uniquely identified by a pair of a partition guid and an encryption epoch.
@@ -25,7 +25,7 @@ We illustrate usage of this library with an example.  Suppose we have classes `U
 
 The `User` class will need to `include DaffyLib::PartitionProvider` and implement the method `provider_partition_guid` which returns an identifier, for instance a user's `guid`.
 
-The `User::Attribute` class will need to `include DaffyLib::PartitionProvider` as well as `include DaffyLib::HasEncryptedAttributes`.  It will need to declare `partition_provider :user`.  
+The `User::Attribute` class will need to `include DaffyLib::PartitionProvider` as well as `include DaffyLib::HasEncryptedAttributes`.  It will need to declare `partition_provider :user`.
 
 There are default implementations of `generate_partition_guid` which returns the linked `User`'s `guid`, as well as a `generate_encryption_epoch` method which defines the encryption epoch, which are the following.
 
@@ -52,7 +52,7 @@ attr_encrypted :values, encryptor: ZtCachingEncryptor, encrypt_method: :zt_encry
                         encode: true, partition_guid: proc { |object| object.generate_partition_guid },
                         encryption_epoch: proc { |object| object.generate_encryption_epoch }, expires_in: 5.minutes
 ```
-                                         
+
 where the `expires_in` field denotes how long a plaintext key should be kept in cache.
 
 Note further that a class can be its own partition provider; i.e. if `User` itself had encrypted attributes, all the steps above for `User::Attributes` apply, except there is no need to declare `partition_provider`, and the recommended implementation for `generate_partition_guid` is to return (or create) the `guid` of the `User`.
@@ -77,7 +77,33 @@ Finally, once existing records have been populated, it is advisable to perform a
 
 Development on this project should occur on separate feature branches and pull requests should be submitted. When submitting a pull request, the pull request comment template should be filled out as much as possible to ensure a quick review and increase the likelihood of the pull request being accepted.
 
+### Ruby
+
+This application requires:
+
+* Ruby version: 2.7.0
+
+If you do not have Ruby installed, it is recommended you use ruby-install and chruby to manage Ruby versions.
+
+```
+brew install ruby-install chruby
+ruby-install ruby 2.7.0
+```
+
+Add the following lines to ~/.bash_profile:
+
+```
+source /usr/local/opt/chruby/share/chruby/chruby.sh
+source /usr/local/opt/chruby/share/chruby/auto.sh
+```
+
+Set Ruby version to 2.7.0:
+
+```
+source ~/.bash_profile
+chruby 2.7.0
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Zetatango/daffy_lib.
-

--- a/README.md
+++ b/README.md
@@ -81,25 +81,25 @@ Development on this project should occur on separate feature branches and pull r
 
 This application requires:
 
-* Ruby version: 2.7.0
+*   Ruby version: 2.7.0
 
 If you do not have Ruby installed, it is recommended you use ruby-install and chruby to manage Ruby versions.
 
-```
+```bash
 brew install ruby-install chruby
 ruby-install ruby 2.7.0
 ```
 
 Add the following lines to ~/.bash_profile:
 
-```
+```bash
 source /usr/local/opt/chruby/share/chruby/chruby.sh
 source /usr/local/opt/chruby/share/chruby/auto.sh
 ```
 
 Set Ruby version to 2.7.0:
 
-```
+```bash
 source ~/.bash_profile
 chruby 2.7.0
 ```


### PR DESCRIPTION
*Related Defect(s), Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/7793

*Why?*

Keeping our codebase up to date is part of the culture here at Ario.

*How?*

Update from 2.6.3 to 2.7.0 via `bundle update --ruby`

*How did this defect occur?*

N/A

*Risks*

Low.

*Requested Reviewers*

@gregfletch @deankeo 

### Note for reviewers

This PR will only be merged when all the ruby 2.7.0 PRs are approved.

### Note for developers

This change requires you to run the following on MacOS
```bash
brew update
brew upgrade
ruby-install ruby 2.7.0
```

and add `chruby 2.7.0` in `~/.bash_profile`, and then run
```bash
source ~/.bash_profile
```

you also may have to run `gem install bundler:2.1.2`