### PR TITLE
~> 0.1.5 - rake task reads encrypted property properly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    daffy_lib (0.1.4)
+    daffy_lib (0.1.5)
       porky_lib
       rails
       redis
@@ -68,7 +68,7 @@ GEM
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.274.0)
+    aws-partitions (1.275.0)
     aws-sdk-core (3.90.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)

--- a/lib/daffy_lib/version.rb
+++ b/lib/daffy_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DaffyLib
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/lib/tasks/db_tasks.rake
+++ b/lib/tasks/db_tasks.rake
@@ -64,7 +64,7 @@ namespace :db do
 
       model_classname.all.each do |record|
         encrypted_attributes.each do |attribute|
-          value = record.attributes.with_indifferent_access[attribute.to_sym]
+          value = record.send(attribute)
           record.send("#{attribute}=", value) unless value.blank?
         end
 


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/6890

*Why?*

Fix re-encrypt rake task (for real): doing a read with `record.attributes.with_indifferent_access` returns `nil` on encrypted fields

*How?*

Change it to `value = record.send(attribute)`.  Actually tested locally that it works (seeing different `encrypted_` values when toggling the caching encryptor flag and running the rake task).

*Risks*

NA

*Requested Reviewers*

Brandon, Brent
