### PR TITLE
Add RbNaCl as runtime dependency

### DIFF
--- a/daffy_lib.gemspec
+++ b/daffy_lib.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'porky_lib'
   spec.add_dependency 'rails'
+  spec.add_dependency 'rbnacl'
   spec.add_dependency 'redis'
 end

--- a/lib/daffy_lib/version.rb
+++ b/lib/daffy_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DaffyLib
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

List the issues or tasks that are related to this pull request.

*Why?*

```
 NameError:
       uninitialized constant DaffyLib::CachingEncryptor::RbNaCl
     # /Users/brandonvrooman/.gem/ruby/2.6.5/gems/daffy_lib-0.1.2/lib/daffy_lib/caching_encryptor.rb:35:in `rescue in zt_encrypt'
     # /Users/brandonvrooman/.gem/ruby/2.6.5/gems/daffy_lib-0.1.2/lib/daffy_lib/caching_encryptor.rb:10:in `zt_encrypt'
     # /Users/brandonvrooman/.gem/ruby/2.6.5/gems/attr_encrypted-3.1.0/lib/attr_encrypted.rb:266:in `encrypt'
     # /Users/brandonvrooman/.gem/ruby/2.6.5/gems/attr_encrypted-3.1.0/lib/attr_encrypted.rb:350:in `encrypt'
     # /Users/brandonvrooman/.gem/ruby/2.6.5/gems/attr_encrypted-3.1.0/lib/attr_encrypted.rb:165:in `block (2 levels) in attr_encrypted'
     # /Users/brandonvrooman/.gem/ruby/2.6.5/gems/attr_encrypted-3.1.0/lib/attr_encrypted/adapters/active_record.rb:77:in `block in attr_encrypted'
...
```

*How?*

Explain the development-level approach you are using in this solution.

*Risks*

Explain the risks that are involved with making this change, if any.

*Requested Reviewers*

List the developers that should review this pull request.
