### PR TITLE
Fix expires_in typo, update package vulnerabilities (nokogiri)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/daffy_lib
     docker:
-      - image: circleci/ruby:2.7.1
+      - image: circleci/ruby:2.7.2
 
     steps:
       - checkout

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '2.7.1'
+ruby '2.7.2'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    daffy_lib (0.1.6)
+    daffy_lib (0.1.7)
       porky_lib
       rails
       redis
@@ -68,20 +68,20 @@ GEM
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.338.0)
-    aws-sdk-core (3.103.0)
+    aws-partitions (1.416.0)
+    aws-sdk-core (3.111.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.36.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-kms (1.41.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.73.0)
-      aws-sdk-core (~> 3, >= 3.102.1)
+    aws-sdk-s3 (1.87.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.1)
+    aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
     builder (3.2.4)
     bundler-audit (0.7.0.1)
@@ -103,7 +103,7 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    ffi (1.13.1)
+    ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.5)
@@ -120,12 +120,13 @@ GEM
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     msgpack (1.3.3)
     nio4r (2.5.4)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -135,6 +136,7 @@ GEM
       msgpack
       rbnacl (= 5.0.0)
       rbnacl-libsodium
+    racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -170,7 +172,7 @@ GEM
       ffi
     rbnacl-libsodium (1.0.16)
       rbnacl (>= 3.0.1)
-    redis (4.2.1)
+    redis (4.2.5)
     regexp_parser (1.7.1)
     rexml (3.2.4)
     rspec (3.9.0)
@@ -263,7 +265,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4

--- a/lib/daffy_lib/services/key_management_service.rb
+++ b/lib/daffy_lib/services/key_management_service.rb
@@ -18,7 +18,7 @@ class DaffyLib::KeyManagementService
     raise InvalidParameterException unless partition_guid.present? && expires_in.present? && cmk_key_id.present?
 
     @partition_guid = partition_guid
-    @expire_in = expires_in
+    @expires_in = expires_in
     @cmk_key_id = cmk_key_id
   end
 

--- a/lib/daffy_lib/version.rb
+++ b/lib/daffy_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DaffyLib
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/14210
https://github.com/Zetatango/zetatango/issues/14230

*Why?*

typo in expire_in / expires_in caused writing encryption keys with nil expiry, meaning they never expire

nokogiri version had vulnerability, so updated that along with ruby to 2.7.2

*How?*

Fix the typo

ruby -> 2.7.2 and `bundle update nokogiri`

*Risks*

Need to delete existing keys still, across applications

*Requested Reviewers*

@bcarr092 @dragoszt 
