### PR TITLE
Update attr_encrypted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Zetatango/attr_encrypted
-  revision: d75795ec86f9980dfc12235b7eb4ee7834c80f85
+  revision: 54cd632c3a4a40d5a7fd67a0f22f78e042c99d4a
   specs:
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)

--- a/lib/daffy_lib/version.rb
+++ b/lib/daffy_lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DaffyLib
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end


### PR DESCRIPTION
*Related Issue(s) or Task(s)*

https://github.com/Zetatango/zetatango/issues/20916

*Why?*

Needed to tweak attr_encrypted fork to remove reference to set_attribute_was which is gone in Rails 7

*How?*

bundle update attr_encrypted

*Risks*

Explain the risks that are involved with making this change, if any.

*Requested Reviewers*

List the developers that should review this pull request.
